### PR TITLE
Fix python-app.yml parse error (env context in job env)

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -126,7 +126,10 @@ jobs:
       matrix:
         shell: [pwsh, powershell]   # PowerShell 7 and Windows PowerShell 5.1
     env:
-      UV_PYTHON: ${{ env.full_test_python }}
+      # Hardcoded to match the workflow-level full_test_python value above.
+      # The `env` context is NOT available inside jobs.<id>.env, so we can't
+      # write `${{ env.full_test_python }}` here — bump both together.
+      UV_PYTHON: "3.13"
     steps:
     - uses: actions/checkout@v6
     - name: Install uv
@@ -134,8 +137,8 @@ jobs:
       with:
         enable-cache: true
         cache-dependency-glob: "pyproject.toml"
-    - name: Set up Python ${{ env.full_test_python }}
-      run: uv python install ${{ env.full_test_python }}
+    - name: Set up Python 3.13
+      run: uv python install 3.13
     - name: Install dependencies
       run: uv sync
     - name: Create dbt profile


### PR DESCRIPTION
## Summary

- Fixes the workflow parse failure introduced by the `windows-quote-test` job: `\${{ env.full_test_python }}` isn't allowed inside `jobs.<id>.env` (only `github`/`needs`/`vars`/`inputs` are permitted there).
- Without this fix, GitHub can't read the workflow's `name: Test App`, so the Actions sidebar shows `.github/workflows/python-app.yml` instead, and every push run completes as a 0-second failure with no jobs.
- Replaces the bad expression with hardcoded `"3.13"` plus a comment to bump alongside the workflow-level `full_test_python`.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/python-app.yml'))"` passes locally.
- [ ] After merge: confirm the sidebar entry returns to "Test App" and that the existing `dbt full build` cells pass on push.
- [ ] After merge: `gh workflow run "Test App" --ref main` and confirm the `windows-quote-test` matrix cells (`pwsh`, `powershell`) appear and run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)